### PR TITLE
Separate jquery from other scripts and move it to <head>

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,10 +13,20 @@ const NODE_PATH = './node_modules/';
 const SRC_PATH = './projects/static_src/';
 const DEST_PATH = './projects/static/';
 
-gulp.task("js", require("unigulp/js")({
+gulp.task("js", ["js:jquery", "js:scripts"]);
+
+gulp.task("js:jquery", require("unigulp/js")({
   name: "js",
   src: [
     NODE_PATH + "jquery/dist/jquery.js",
+  ],
+  dest: DEST_PATH + "js/jquery.js",
+  production,
+}));
+
+gulp.task("js:scripts", require("unigulp/js")({
+  name: "js",
+  src: [
     NODE_PATH + "bootstrap-sass/assets/javascripts/bootstrap.js",
     SRC_PATH + "js/general.js",
   ],

--- a/projects/templates/base.html
+++ b/projects/templates/base.html
@@ -10,6 +10,10 @@
     <title>{% block title %}Kaavapino{% endblock %} - Kaavapino</title>
     <link rel="stylesheet" type="text/css" href="{% static 'css/styles.css' %}" />
     <link rel="icon" type="image/x-icon" href="{% static 'img/favicon.ico' %}">
+
+    {% comment %}We need to load jquery here because we need it with inline scripts{% endcomment %}
+    <script src="{% static 'js/jquery.js' %}"></script>
+
     {% block extrahead %}{% endblock %}
 </head>
 <body class="{% block body_class %}{% endblock %}" {% block extra_body_tags %}{% endblock %}>


### PR DESCRIPTION
We need this because jquery is used in the templates were
the scripts are rendered before the scripts in the end of
the DOM