### PR TITLE
Use non-binary version of psycopg2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@
 #
 #   prequ update
 #
+--no-binary psycopg2
+
 appdirs==1.4.3            # via black
 appnope==0.1.0            # via ipython
 atomicwrites==1.2.1       # via pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 #
 #   prequ update
 #
+--no-binary psycopg2
+
 certifi==2018.10.15       # via requests
 chardet==3.0.4            # via requests
 defusedxml==0.5.0         # via python3-openid

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ ignore=D100,D104,D105,D200,D203,D400
 [prequ]
 annotate = yes
 requirements =
+    --no-binary psycopg2
     Django~=2.1
     django-helusers
     django-environ==0.4.4


### PR DESCRIPTION
For production use you are advised to use the source distribution. [source](http://initd.org/psycopg/docs/install.html#binary-install-from-pypi) Also this should take care of the warning that can been seen if not explicitly using `psycopg2-binary`.