### PR TITLE
Add docker-compose instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Install PostgreSQL and PostGIS.
 
 ### Creating a Python virtualenv
 
-Create a Python 3.x virtualenv either using the [`venv`](https://docs.python.org/3/library/venv.html) tool or using
+Create a Python >=3.6 virtualenv either using the [`venv`](https://docs.python.org/3/library/venv.html) tool or using
 the great [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) toolset. Assuming the latter,
 once installed, simply do:
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,25 @@ Project management system for city planning projects.
 
 ## Development
 
+It is possible to either use `docker-compose` or set up the development environment manually
+as described below.
+
+### Using docker-compose
+
+Development environment can be initialized using `docker-compose`.
+You need to have `docker` and `docker-compose` available on your system.
+
+To bring up the dev environment run:
+
+    docker-compose up
+
+To manage docker-compose setup:
+
+    docker-compose build                # Builds project container from the Dockerfile
+    docker-compose up -d                # Start all required services in the background
+    docker-compose stop                 # Stop services
+    docker exec -it kaavapino-api bash  # Open bash into the django container
+
 ### Install required system packages
 
 #### PostgreSQL and PostGIS

--- a/projects/models/attribute.py
+++ b/projects/models/attribute.py
@@ -20,6 +20,8 @@ validate_identifier = RegexValidator(
 
 
 class Attribute(models.Model):
+    """Defines a single attribute type."""
+
     TYPE_INTEGER = "integer"
     TYPE_SHORT_STRING = "short_string"
     TYPE_LONG_STRING = "long_string"
@@ -138,6 +140,8 @@ class Attribute(models.Model):
 
 
 class AttributeValueChoice(models.Model):
+    """Single value choice for a single attribute."""
+
     attribute = models.ForeignKey(
         Attribute,
         verbose_name=_("attribute"),

--- a/projects/models/document.py
+++ b/projects/models/document.py
@@ -5,6 +5,10 @@ from .project import ProjectPhase
 
 
 class DocumentTemplate(models.Model):
+    """Document that is produced in a certain phase of a project. Project attribute
+    data is rendered into the given document template.
+    """
+
     name = models.CharField(max_length=255, verbose_name=_("name"))
     project_phase = models.ForeignKey(
         ProjectPhase,

--- a/projects/models/project.py
+++ b/projects/models/project.py
@@ -11,6 +11,8 @@ from .attribute import Attribute
 
 
 class ProjectType(models.Model):
+    """Types of projects that the system supports e.g. asemakaava/city plan."""
+
     name = models.CharField(max_length=255, verbose_name=_("name"))
 
     class Meta:
@@ -23,6 +25,8 @@ class ProjectType(models.Model):
 
 
 class Project(models.Model):
+    """Represents a single project in the system."""
+
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         verbose_name=_("user"),
@@ -141,6 +145,7 @@ class Project(models.Model):
                     self.attribute_data.pop(identifier, None)
 
     def get_time_line(self):
+        """Produce data for a timeline graph for the given project."""
         timeline = [
             {
                 "content": "Luontipvm",
@@ -222,6 +227,8 @@ class Project(models.Model):
 
 
 class ProjectPhase(models.Model):
+    """Describes a phase of a certain project type."""
+
     project_type = models.ForeignKey(
         ProjectType,
         verbose_name=_("project type"),
@@ -245,6 +252,8 @@ class ProjectPhase(models.Model):
 
 
 class ProjectPhaseLog(models.Model):
+    """Records project phase changes."""
+
     project = models.ForeignKey(
         "Project",
         verbose_name=_("project"),
@@ -277,6 +286,8 @@ class ProjectPhaseLog(models.Model):
 
 
 class ProjectPhaseSection(models.Model):
+    """Defines a section within a project phase."""
+
     phase = models.ForeignKey(
         ProjectPhase,
         verbose_name=_("phase"),
@@ -305,6 +316,8 @@ class ProjectPhaseSection(models.Model):
 
 
 class ProjectPhaseSectionAttribute(models.Model):
+    """Links an attribute into a project phase section."""
+
     attribute = models.ForeignKey(
         Attribute, verbose_name=_("attribute"), on_delete=models.CASCADE
     )
@@ -327,6 +340,8 @@ class ProjectPhaseSectionAttribute(models.Model):
 
 
 class ProjectAttributeImage(models.Model):
+    """Project attribute value that is an image."""
+
     attribute = models.ForeignKey(
         Attribute,
         verbose_name=_("attribute"),


### PR DESCRIPTION
This PR adds short instructions for setting up the local development environment with `docker-compose`. Also adds some docstrings to the existing models.