### PR TITLE
Extend project type metadata with its own serializers

### DIFF
--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -7,11 +7,48 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer
 
-from projects.models import Project, ProjectPhase, ProjectPhaseSection, ProjectType
+from projects.models import (
+    Project,
+    ProjectPhase,
+    ProjectPhaseSection,
+    ProjectType,
+    Attribute,
+)
 from projects.serializers.section import create_section_serializer
 
 
+class ProjectTypeMetadataCardAttributeSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="identifier")
+    label = serializers.CharField(source="name")
+    type = serializers.CharField(source="value_type")
+
+    class Meta:
+        fields = ["name", "label", "type"]
+        model = Attribute
+
+
+class ProjectTypeMetadataSerializer(serializers.Serializer):
+    normal_project_card_attributes = serializers.SerializerMethodField()
+    extended_project_card_attributes = serializers.SerializerMethodField()
+
+    def get_normal_project_card_attributes(self, metadata):
+        return self._get_card_attributes(metadata, "normal_project_card_attributes")
+
+    def get_extended_project_card_attributes(self, metadata):
+        return self._get_card_attributes(metadata, "extended_project_card_attributes")
+
+    def _get_card_attributes(self, metadata, field):
+        attribute_identifiers = metadata.get(field, [])
+        if not attribute_identifiers:
+            return attribute_identifiers
+
+        attributes = Attribute.objects.filter(identifier__in=attribute_identifiers)
+        return ProjectTypeMetadataCardAttributeSerializer(attributes, many=True).data
+
+
 class ProjectTypeSerializer(serializers.ModelSerializer):
+    metadata = ProjectTypeMetadataSerializer()
+
     class Meta:
         model = ProjectType
         fields = ["id", "name", "metadata"]

--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -7,51 +7,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import Serializer
 
-from projects.models import (
-    Project,
-    ProjectPhase,
-    ProjectPhaseSection,
-    ProjectType,
-    Attribute,
-)
+from projects.models import Project, ProjectPhase, ProjectPhaseSection, ProjectType
 from projects.serializers.section import create_section_serializer
-
-
-class ProjectTypeMetadataCardAttributeSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source="identifier")
-    label = serializers.CharField(source="name")
-    type = serializers.CharField(source="value_type")
-
-    class Meta:
-        fields = ["name", "label", "type"]
-        model = Attribute
-
-
-class ProjectTypeMetadataSerializer(serializers.Serializer):
-    normal_project_card_attributes = serializers.SerializerMethodField()
-    extended_project_card_attributes = serializers.SerializerMethodField()
-
-    def get_normal_project_card_attributes(self, metadata):
-        return self._get_card_attributes(metadata, "normal_project_card_attributes")
-
-    def get_extended_project_card_attributes(self, metadata):
-        return self._get_card_attributes(metadata, "extended_project_card_attributes")
-
-    def _get_card_attributes(self, metadata, field):
-        attribute_identifiers = metadata.get(field, [])
-        if not attribute_identifiers:
-            return attribute_identifiers
-
-        attributes = Attribute.objects.filter(identifier__in=attribute_identifiers)
-        return ProjectTypeMetadataCardAttributeSerializer(attributes, many=True).data
-
-
-class ProjectTypeSerializer(serializers.ModelSerializer):
-    metadata = ProjectTypeMetadataSerializer()
-
-    class Meta:
-        model = ProjectType
-        fields = ["id", "name", "metadata"]
 
 
 class SectionData(NamedTuple):

--- a/projects/serializers/projecttype.py
+++ b/projects/serializers/projecttype.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+from projects.models import ProjectType, Attribute
+
+
+class ProjectTypeMetadataCardAttributeSerializer(serializers.ModelSerializer):
+    name = serializers.CharField(source="identifier")
+    label = serializers.CharField(source="name")
+    type = serializers.CharField(source="value_type")
+
+    class Meta:
+        fields = ["name", "label", "type"]
+        model = Attribute
+
+
+class ProjectTypeMetadataSerializer(serializers.Serializer):
+    normal_project_card_attributes = serializers.SerializerMethodField()
+    extended_project_card_attributes = serializers.SerializerMethodField()
+
+    def get_normal_project_card_attributes(self, metadata):
+        return self._get_card_attributes(metadata, "normal_project_card_attributes")
+
+    def get_extended_project_card_attributes(self, metadata):
+        return self._get_card_attributes(metadata, "extended_project_card_attributes")
+
+    def _get_card_attributes(self, metadata, field):
+        attribute_identifiers = metadata.get(field, [])
+        if not attribute_identifiers:
+            return attribute_identifiers
+
+        attributes = Attribute.objects.filter(identifier__in=attribute_identifiers)
+        return ProjectTypeMetadataCardAttributeSerializer(attributes, many=True).data
+
+
+class ProjectTypeSerializer(serializers.ModelSerializer):
+    metadata = ProjectTypeMetadataSerializer()
+
+    class Meta:
+        model = ProjectType
+        fields = ["id", "name", "metadata"]

--- a/projects/views.py
+++ b/projects/views.py
@@ -1,12 +1,9 @@
 from rest_framework import viewsets
 
 from projects.models import Project, ProjectPhase, ProjectType
-from projects.serializers.project import (
-    ProjectSerializer,
-    ProjectPhaseSerializer,
-    ProjectTypeSerializer,
-)
+from projects.serializers.project import ProjectSerializer, ProjectPhaseSerializer
 from projects.serializers.projectschema import ProjectTypeSchemaSerializer
+from projects.serializers.projecttype import ProjectTypeSerializer
 
 
 class ProjectTypeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
By popular demand from Olli I added a serializer for metadata so that the project cars (hankekortti) does not have to fetch an entire schema in order to render info about the fields to display.