### PR TITLE
Add user metadata

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -24,7 +24,7 @@ class ProjectTypeViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
-    queryset = Project.objects.all()
+    queryset = Project.objects.all().select_related("user")
     serializer_class = ProjectSerializer
 
     def get_serializer_context(self):

--- a/projects/views.py
+++ b/projects/views.py
@@ -27,6 +27,11 @@ class ProjectViewSet(viewsets.ModelViewSet):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context["action"] = self.action
+        return context
+
     @action(methods=["put"], detail=True, parser_classes=[MultiPartParser])
     def files(self, request, pk=None):
         project = self.get_object()


### PR DESCRIPTION
Adds user metadata to projects so that users do not have to be fetched separately.

Example:
```
{
    "user": "<UUID1>",
    "created_at": "<redacted>",
    "modified_at": "<redacted>",
    "name": "test",
    "identifier": "test",
    "type": 1,
    "attribute_data": {
        "vastuuyksikko": "<UUID2>"
    },
    "phase": 1,
    "geometry": null,
    "id": 1,
    "_metadata": {
        "users": [
            {
                "id": "<UUID1>",
                "department_name": null,
                "first_name": "",
                "last_name": "",
                "is_active": true,
                "is_staff": true,
                "email": "test2@example.com"
            },
            {
                "id": "<UUID2>",
                "department_name": null,
                "first_name": "",
                "last_name": "",
                "is_active": true,
                "is_staff": true,
                "email": "test@example.com"
            }
        ]
    }
}
```