### PR TITLE
Changed PersonnelSerializer to use business number instead of a personal one

### DIFF
--- a/projects/helpers.py
+++ b/projects/helpers.py
@@ -515,7 +515,7 @@ def set_kaavoitus_api_data_in_attribute_data(attribute_data):
         set_in_attribute_data(attribute_data, path, value)
 
 def get_ad_user(id):
-    url = f"{settings.GRAPH_API_BASE_URL}/v1.0/users/{id}?$select=companyName,givenName,id,jobTitle,mail,mobilePhone,officeLocation,surname"
+    url = f"{settings.GRAPH_API_BASE_URL}/v1.0/users/{id}?$select=companyName,givenName,id,jobTitle,mail,mobilePhone,businessPhones,officeLocation,surname"
     try:
         response = cache.get(url)
     except TypeError:

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -49,10 +49,17 @@ class UserSerializer(serializers.ModelSerializer):
 class PersonnelSerializer(serializers.Serializer):
     id = serializers.CharField()
     name = serializers.SerializerMethodField()
-    phone = serializers.CharField(source="mobilePhone")
+    phone = serializers.SerializerMethodField()
     email = serializers.CharField(source="mail")
     title = serializers.CharField(source="jobTitle")
     office = serializers.CharField(source="officeLocation")
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_phone(self, user):
+        business_phones = user["businessPhones"]
+        if business_phones and len(business_phones) > 0:
+            return business_phones[0]
+        return user["mobilePhone"]
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_name(self, user):

--- a/users/views.py
+++ b/users/views.py
@@ -75,7 +75,7 @@ class PersonnelDetail(APIView):
             )
 
         response = requests.get(
-            f"{settings.GRAPH_API_BASE_URL}/v1.0/users/{pk}?$select=companyName,givenName,id,jobTitle,mail,mobilePhone,officeLocation,surname",
+            f"{settings.GRAPH_API_BASE_URL}/v1.0/users/{pk}?$select=companyName,givenName,id,jobTitle,mail,mobilePhone,businessPhones,officeLocation,surname",
             headers={
                 "Authorization": f"Bearer {token}",
             },


### PR DESCRIPTION
Business phone should be shown for other users instead of a personal one. In case business phone number is missing then personal number is shown.