### PR TITLE
KAAV-390 fix rich text validation inconsistency between Kaavapino-ui and Kaavapino validator

### DIFF
--- a/projects/serializers/section.py
+++ b/projects/serializers/section.py
@@ -58,8 +58,8 @@ def get_rich_text_validator(attribute):
             for item in value["ops"]:
                 total_length += len(item["insert"])
 
-            # 1 reduced from total_length because strings in 'insert' always have line break
-            # so the actual value visible to the user will always be 1 less than the actual one
+            # Decrease 1 from total_length because string in last 'insert' operation will always have line break
+            # so the value visible to the user will always be 1 less than what is added to total_length here
             if attribute.character_limit and total_length - 1 > attribute.character_limit:
                 raise ValidationError(
                     {attribute.identifier: error_msg}

--- a/projects/serializers/section.py
+++ b/projects/serializers/section.py
@@ -58,7 +58,9 @@ def get_rich_text_validator(attribute):
             for item in value["ops"]:
                 total_length += len(item["insert"])
 
-            if attribute.character_limit and total_length > attribute.character_limit:
+            # 1 reduced from total_length because strings in 'insert' always have line break
+            # so the actual value visible to the user will always be 1 less than the actual one
+            if attribute.character_limit and total_length - 1 > attribute.character_limit:
                 raise ValidationError(
                     {attribute.identifier: error_msg}
                 )


### PR DESCRIPTION
React-quill will always add a line break to the end of the text (last insert operation). This is correct and expected behaviour of how the text is received from the rich text field component. This however causes the validator in section.py#get_rich_text_validator to always compare the text 1 character longer than the actual value is.