### PR TITLE
Increased pagination page size of AttributeViewSet from 100 to 2000

### DIFF
--- a/projects/views.py
+++ b/projects/views.py
@@ -22,7 +22,7 @@ from drf_spectacular.utils import (
 )
 from drf_spectacular.types import OpenApiTypes
 from private_storage.views import PrivateStorageDetailView
-from rest_framework import viewsets, filters, status
+from rest_framework import viewsets, filters, status, pagination
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
@@ -807,9 +807,14 @@ class ProjectCardSchemaViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ProjectCardSchemaSerializer
 
 
+class AttributePagination(pagination.PageNumberPagination):
+    page_size = 2000
+
+
 class AttributeViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Attribute.objects.all()
     serializer_class = SimpleAttributeSerializer
+    pagination_class = AttributePagination
 
 
 @extend_schema(


### PR DESCRIPTION
Previously the 100 value was the default value from settings.py. The dataset size is relatively small so there should be no need to request it in many parts.