### PR TITLE
Add validation to get_geoserver_data api calls

### DIFF
--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -370,7 +370,7 @@ class ProjectOnMapOverviewSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier and re.match("^(\d{4}_\d{1,3})$"):
+        if identifier and re.compile("^(\d{4}_\d{1,3})$").match(identifier):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             if cache.get(url) is not None:
@@ -642,13 +642,14 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier and re.match("^(\d{4}_\d{1,3})$"):
+        if identifier and re.compile("^(\d{4}_\d{1,3})$").match(identifier):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             response = requests.get(
                 url,
                 headers={"Authorization": f"Token {settings.KAAVOITUS_API_AUTH_TOKEN}"},
             )
+            print(f'Received response {response.status_code} for identifier {identifier}')
             if response.status_code == 200:
                 cache.set(url, response, 86400)  # 1 day
             elif response.status_code == 404:

--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -390,7 +390,7 @@ class ProjectOnMapOverviewSerializer(serializers.ModelSerializer):
                         response.text
                     ))
                 else:
-                    cache.set(url, response, 3600)  # 1 hours
+                    cache.set(url, response, 3600)  # 1 hour
 
             if response.status_code == 200:
                 return response.json()

--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -370,7 +370,7 @@ class ProjectOnMapOverviewSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier and re.compile("^(\d{4}_\d{1,3})$").match(identifier):
+        if identifier and re.compile("^\d{4}_\d{1,3}$").match(identifier):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             if cache.get(url) is not None:
@@ -642,7 +642,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier and re.compile("^(\d{4}_\d{1,3})$").match(identifier):
+        if identifier and re.compile("^\d{4}_\d{1,3}$").match(identifier):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             response = requests.get(

--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -383,14 +383,14 @@ class ProjectOnMapOverviewSerializer(serializers.ModelSerializer):
                 if response.status_code == 200:
                     cache.set(url, response, 86400)  # 1 day
                 elif response.status_code == 404:
-                    cache.set(url, response, 900)  # 15 minutes
+                    cache.set(url, response, 28800)  # 8 hours
                 elif response.status_code >= 500:
                     log.error("Kaavoitus-api connection error: {} {}".format(
                         response.status_code,
                         response.text
                     ))
                 else:
-                    cache.set(url, response, 180)  # 3 minutes
+                    cache.set(url, response, 3600)  # 1 hours
 
             if response.status_code == 200:
                 return response.json()
@@ -649,18 +649,17 @@ class ProjectSerializer(serializers.ModelSerializer):
                 url,
                 headers={"Authorization": f"Token {settings.KAAVOITUS_API_AUTH_TOKEN}"},
             )
-            print(f'Received response {response.status_code} for identifier {identifier}')
             if response.status_code == 200:
                 cache.set(url, response, 86400)  # 1 day
             elif response.status_code == 404:
-                cache.set(url, response, 900)  # 15 minutes
+                cache.set(url, response, 28800)  # 8 hours
             elif response.status_code >= 500:
                 log.error("Kaavoitus-api connection error: {} {}".format(
                     response.status_code,
                     response.text
                 ))
             else:
-                cache.set(url, response, 180)  # 3 minutes
+                cache.set(url, response, 3600)  # 1 hour
 
             if response.status_code == 200:
                 return response.json()

--- a/projects/serializers/project.py
+++ b/projects/serializers/project.py
@@ -370,7 +370,7 @@ class ProjectOnMapOverviewSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier:
+        if identifier and re.match("^(\d{4}_\d{1,3})$"):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             if cache.get(url) is not None:
@@ -642,7 +642,7 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_geoserver_data(self, project):
         identifier = project.attribute_data.get("hankenumero")
-        if identifier:
+        if identifier and re.match("^(\d{4}_\d{1,3})$"):
             url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
 
             response = requests.get(

--- a/projects/tasks.py
+++ b/projects/tasks.py
@@ -20,7 +20,7 @@ def refresh_on_map_overview_cache():
     for project in Project.objects.all():
         identifier = project.attribute_data.get("hankenumero")
 
-        if not identifier or not re.compile("^(\d{4}_\d{1,3})$").match(identifier):
+        if not identifier or not re.compile("^\d{4}_\d{1,3}$").match(identifier):
             continue
 
         url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"

--- a/projects/tasks.py
+++ b/projects/tasks.py
@@ -1,4 +1,6 @@
 import logging
+import re
+
 import requests
 
 from django.conf import settings
@@ -18,7 +20,7 @@ def refresh_on_map_overview_cache():
     for project in Project.objects.all():
         identifier = project.attribute_data.get("hankenumero")
 
-        if not identifier:
+        if not identifier or not re.compile("^(\d{4}_\d{1,3})$").match(identifier):
             continue
 
         url = f"{settings.KAAVOITUS_API_BASE_URL}/geoserver/v1/suunnittelualue/{identifier}"
@@ -30,9 +32,9 @@ def refresh_on_map_overview_cache():
         if response.status_code == 200:
             cache.set(url, response, 86400)  # 1 day
         elif response.status_code == 404:
-            cache.set(url, response, 900)  # 15 minutes
+            cache.set(url, response, 28800)  # 8 hours
         else:
-            cache.set(url, response, 180)  # 3 minutes
+            cache.set(url, response, 3600)  # 1 hour
 
 def refresh_project_schedule_cache():
     project_schedule_cache = cache.get("serialized_project_schedules", {})


### PR DESCRIPTION
Added validation by regex (^(\d{4}_\d{1,3})$) to get_geoserver_data api calls. In addition to that increased cache timeouts for responses. Response can still be refreshed any time by loading up the project card page.