### PR TITLE
KAAV-1251 Aikataulun muokkausnäkymässä vahvista kaavehdotuksen päättyminen –boksi väärässä kohdassa

### DIFF
--- a/projects/importing/attribute.py
+++ b/projects/importing/attribute.py
@@ -1404,7 +1404,10 @@ class AttributeImporter:
     def calculate_deadline_index(locations):
         deadline_index = 0
         for index, location in enumerate(locations, start=1):
-            deadline_index += int(int(location) * 10000 / int(10 ** index))
+            if index == 3:
+                deadline_index += int(int(location) * 10000 / int(10 ** 4))
+            else:
+                deadline_index += int(int(location) * 10000 / int(10 ** index))
         return deadline_index
 
     @staticmethod


### PR DESCRIPTION
-Import timetable deadlines to convert last two digits correctly to deadline index.