### PR TITLE
KAPI-33 timeout adjustment to 56s

### DIFF
--- a/projects/helpers.py
+++ b/projects/helpers.py
@@ -131,7 +131,7 @@ def update_paikkatieto(attribute_data, use_cached=True):
             response = requests.get(
                 url,
                 headers={"Authorization": f"Token {settings.KAAVOITUS_API_AUTH_TOKEN}"},
-                timeout=58
+                timeout=56
             )
             if response.status_code == 200:
                 cache.set(url, response, 86400)  # 24 hours

--- a/projects/helpers.py
+++ b/projects/helpers.py
@@ -131,7 +131,7 @@ def update_paikkatieto(attribute_data, use_cached=True):
             response = requests.get(
                 url,
                 headers={"Authorization": f"Token {settings.KAAVOITUS_API_AUTH_TOKEN}"},
-                timeout=30
+                timeout=58
             )
             if response.status_code == 200:
                 cache.set(url, response, 86400)  # 24 hours


### PR DESCRIPTION
Some paikkatieto queries can take over 50 sec to complete, so longer
timeout was needed. 56 used instead of 60 because openshift route has
a timeout of 60, and can cause a page to be stuck loading if triggered.